### PR TITLE
SEB-2057 OutOfMemory Issue

### DIFF
--- a/.ebextensions/04_jvm_variables.config
+++ b/.ebextensions/04_jvm_variables.config
@@ -1,0 +1,5 @@
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    XX:MaxPermSize: 512m
+    Xmx: 1536m
+    Xms: 1024m


### PR DESCRIPTION
Changes attempt to address OutOfMemory heap errors encountered by the Java process in the production Nightly ReCAP Harvester Beanstalk application.

* Adds JVM variables configuration file to .ebextensions for custom control over the Java heap size. Increases the maximum heap size to 1536m or 1.5g.