### PR TITLE
SEB-2057 Change JVM variables to use MAVEN_OPTS to adjust heap

### DIFF
--- a/.ebextensions/04_jvm_variables.config
+++ b/.ebextensions/04_jvm_variables.config
@@ -1,5 +1,3 @@
 option_settings:
   aws:elasticbeanstalk:application:environment:
-    XX:MaxPermSize: 512m
-    Xmx: 1536m
-    Xms: 1024m
+    MAVEN_OPTS=-Xmx1536m


### PR DESCRIPTION
This change replaces the JVM variables with MAVEN_OPTS instead which should affect the heap size properly. The JVM vars added previously were added to the environment as written, but didn't affect the heap size. Trying this option as an alternative especially since Maven is in use.

May try using another alternative and try to add the JVM variables as command line arguments for Elastic Beanstalk on start up if possible.